### PR TITLE
[RFR] return null when crossref return a 404 error

### DIFF
--- a/lib/services/getTitleFromDOI.js
+++ b/lib/services/getTitleFromDOI.js
@@ -3,11 +3,13 @@ import { crossref } from 'config';
 import get from 'lodash.get';
 
 export default async term => {
-    const requestData = {
-        url: `${crossref}${term}`,
-    };
-
-    const result = await request.get(requestData);
-
-    return get(JSON.parse(result), 'message.title[0]');
+    try {
+        const result = await request.get({
+            url: `${crossref}${term}`,
+        });
+        return get(JSON.parse(result), 'message.title[0]');
+    } catch (error) {
+        // 404 crossref
+        return null;
+    }
 };


### PR DESCRIPTION
https://trello.com/c/eCDcToqL/152-properly-handle-crossref-404-error