### PR TITLE
replace primary_institutes by primary_institute

### DIFF
--- a/lib/models/SectionCN.js
+++ b/lib/models/SectionCN.js
@@ -34,20 +34,30 @@ function SectionCN(client) {
                 sectionCN,
             );
 
-            const primaryInstitutes = yield updatePrimaryInstitutes(
-                sectionCN.primary_institutes,
-                insertedSectionCN.id,
-            );
-            const secondaryInstitutes = yield updateSecondaryInstitutes(
-                sectionCN.secondary_institutes,
-                insertedSectionCN.id,
-            );
+            if (sectionCN.primary_institutes) {
+                yield client.query({
+                    sql:
+                        'INSERT INTO section_cn_primary_institute (section_cn_id, institute_id) VALUES ($section_cn_id, $primary_institute)',
+                    parameters: {
+                        primary_institute: sectionCN.primary_institutes,
+                        section_cn_id: insertedSectionCN.id,
+                    },
+                });
+            }
+
+            let secondaryInstitutes = [];
+            if (sectionCN.secondary_institutes) {
+                secondaryInstitutes = yield updateSecondaryInstitutes(
+                    sectionCN.secondary_institutes,
+                    insertedSectionCN.id,
+                );
+            }
 
             yield client.commit();
 
             return {
                 ...insertedSectionCN,
-                primary_institutes: primaryInstitutes,
+                primary_institutes: sectionCN.primary_institutes,
                 secondary_institutes: secondaryInstitutes,
             };
         } catch (error) {
@@ -74,20 +84,29 @@ function SectionCN(client) {
                     id: selector,
                 });
             }
-            const primaryInstitutes = yield updatePrimaryInstitutes(
-                sectionCN.primary_institutes,
-                updatedSectionCN.id,
-            );
-            const secondaryInstitutes = yield updateSecondaryInstitutes(
-                sectionCN.secondary_institutes,
-                updatedSectionCN.id,
-            );
+            if (sectionCN.primary_institutes) {
+                yield client.query({
+                    sql:
+                        'UPDATE section_cn_primary_institute SET institute_id = $primary_institute WHERE section_cn_id = $section_cn_id',
+                    parameters: {
+                        primary_institute: sectionCN.primary_institutes,
+                        section_cn_id: sectionCN.id,
+                    },
+                });
+            }
+            let secondaryInstitutes = [];
+            if (sectionCN.secondary_institutes) {
+                secondaryInstitutes = yield updateSecondaryInstitutes(
+                    sectionCN.secondary_institutes,
+                    updatedSectionCN.id,
+                );
+            }
 
             yield client.commit();
 
             return {
                 ...updatedSectionCN,
-                primary_institutes: primaryInstitutes,
+                primary_institutes: sectionCN.primary_institutes,
                 secondary_institutes: secondaryInstitutes,
             };
         } catch (error) {

--- a/lib/queries/sectionCNQueries.js
+++ b/lib/queries/sectionCNQueries.js
@@ -4,11 +4,11 @@ import {
     selectByOrderedFieldValuesQuery,
 } from 'co-postgres-queries';
 
-const selectPrimaryInstitutes = `SELECT institute_id
+const selectPrimaryInstitute = `SELECT institute_id 
 FROM section_cn_primary_institute
 WHERE section_cn_primary_institute.section_cn_id = section_cn.id`;
 
-const selectSecondaryInstitutes = `SELECT institute_id
+const selectSecondaryInstitutes = `SELECT institute_id 
 FROM section_cn_secondary_institute
 WHERE section_cn_secondary_institute.section_cn_id = section_cn.id`;
 
@@ -17,13 +17,13 @@ const returnFields = [
     'name',
     'code',
     'comment',
-    `ARRAY(${selectPrimaryInstitutes}) AS primary_institutes`,
+    `ARRAY(${selectPrimaryInstitute}) AS primary_institutes`,
     `ARRAY(${selectSecondaryInstitutes}) AS secondary_institutes`,
 ];
 
 const adminReturnFields = [
     ...returnFields,
-    `ARRAY(${selectPrimaryInstitutes}) as primary_institutes`,
+    `ARRAY(${selectPrimaryInstitute}) AS primary_institutes`,
     `ARRAY(${selectSecondaryInstitutes}) as secondary_institutes`,
 ];
 

--- a/test/utils/fixtureLoader.js
+++ b/test/utils/fixtureLoader.js
@@ -121,7 +121,7 @@ export default function(postgres) {
         const defaultSectionCN = {
             name: 'la secion',
             code: '1',
-            primary_institutes: [],
+            primary_institutes: null,
             primary_units: [],
         };
         return yield sectionCNQueries.insertOne({


### PR DESCRIPTION
Dans l'ancien système primary_institutes était un array. Aujourd'hui ce champ est unique ce qui occasionne des erreurs lorsqu'il est dupliqué.
Ce problème occasionnait également un comportement différent lors des test et sur l'admin.