### PR TITLE
(DNM) Feat: Update docker-compose to create named volumes

### DIFF
--- a/docker-compose.dev.unix.yml
+++ b/docker-compose.dev.unix.yml
@@ -3,6 +3,8 @@ version: "3.5"
 services:
   redis:
     image: redis:6.2.6
+    volumes:
+      - redis_data_unix:/data
     networks:
       - bibbackend
 
@@ -13,13 +15,13 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: bibapi-dev
-      PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - 5432:5432
     networks:
       - bibbackend
     volumes:
       - ./backups:/backups
+      - postgres_data_unix:/var/lib/postgresql/data
   adminer:
     image: adminer
     ports:
@@ -69,3 +71,7 @@ networks:
     external: true
   bibfrontend:
     external: true
+
+volumes:
+  postgres_data_unix:
+  redis_data_unix:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,6 +3,8 @@ version: "3.5"
 services:
   redis:
     image: redis:6.2.6
+    volumes:
+      - redis_data_dev:/data
     networks:
       - bibbackend
 
@@ -13,14 +15,13 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: bibapi-dev
-      PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - 5432:5432
     networks:
       - bibbackend
     volumes:
       - ./backups:/backups
-      - /applis/bibapi/home/postgresql-dev:/var/lib/postgresql/data/pgdata
+      - postgres_data_dev:/var/lib/postgresql/data
   adminer:
     image: adminer
     ports:
@@ -70,3 +71,7 @@ networks:
     external: true
   bibfrontend:
     external: true
+
+volumes:
+  redis_data_dev:
+  postgres_data_dev:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
   redis:
     image: redis:6.2.6
     restart: always
+    volumes:
+      - redis_data_prod:/data
     networks:
       - bibbackend
 
@@ -15,10 +17,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: bibapi-prod
-      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - ./backups:/backups
-      - /applis/bibapi/home/postgresql:/var/lib/postgresql/data/pgdata
+      - postgres_data_prod:/var/lib/postgresql/data
     ports:
       - 60000:5432
     networks:
@@ -62,3 +63,7 @@ networks:
     external: true
   bibfrontend:
     external: true
+
+volumes:
+  redis_data_prod:
+  postgres_data_prod:


### PR DESCRIPTION
After investigation:

Services like `Postgres` require that a volume be defined according to specific rules. For example for `Postgres`, a volume must be associated to `/var/lib/postgresql/data/`.
This is not the case at the moment, we only make binds between the data and the container. So the service itself will create an anonymous volume.

The solution would be to mount the volumes requested by the services, but this would cause us to lose the current volumes and the data that goes with them.

To apply this modification, it will be necessary before deploying, to carry out a backup of the Postgres base and redis.
Deploy with the new volumes, and apply the dumps. 