### PR TITLE
fix: add search on resourceTypeGeneral to search data of type Dataset

### DIFF
--- a/lib/services/parseSearchQuery.js
+++ b/lib/services/parseSearchQuery.js
@@ -93,7 +93,7 @@ export const parseMetadoreSearch = (rawQuery) => {
                   .map((term) => `(${field}:*${term}*)`)
                   .join('AND')
             : `(${field}:"${term}")`;
-    query += 'AND(attributes.types.resourceType:Dataset)';
+    query += 'AND(attributes.types.resourceType:Dataset)OR(attributes.types.resourceTypeGeneral:Dataset)';
     const metadoreQuery = {
         query,
         size,


### PR DESCRIPTION
Using resourceTypeGeneral in the query will give more results in Dataset type in addition to resourceType.